### PR TITLE
Creates database structure for documents

### DIFF
--- a/appORM/models/docs.js
+++ b/appORM/models/docs.js
@@ -16,6 +16,7 @@ var docSchema = mongoose.Schema({
   lead_image_url:  String,
   title:  String,
   rendered_pages:  String,
+  paragraphs: Array
 });
 
 var Doc = mongoose.model('Doc', docSchema);

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -30,39 +30,45 @@ exports.fetchDocs = function(req, res) {
 };
 
 exports.saveDoc = function(req, res) {
-  // var uri = req.body.url;
+  var url = req.body.url;
 
   // if (!util.isValidUrl(uri)) {
   //   console.log('Not a valid url: ', uri);
   //   return res.send(404);
   // }
 
-  // Doc.findOne({ url: uri }).exec(function(err, found) {
-  //   if (found) {
-  //     res.send(200, found);
-  //   } else {
-  //     util.getUrlTitle(uri, function(err, title) {
-  //       if (err) {
-  //         console.log('Error reading URL heading: ', err);
-  //         return res.send(404);
-  //       }
-  //       var newDoc = new Doc({
-  //         url: uri,
-  //         title: title,
-  //         base_url: req.headers.origin,
-  //         visits: 0
-  //       });
+  Doc.findOne({ 'url': url }).exec(function(err, found) {
+    if (found) {
+      res.send(200, found);
+    } else {     
+      var newDoc = new Doc({
+        'domain': req.body.domain,
+        'next_page_id': req.body.next_page_id,
+        'url': req.body.url,
+        'short_url': req.body.short_url,
+        'author': req.body.author,
+        'excerpt': req.body.excerpt,
+        'direction': req.body.direction,
+        'word_count': req.body.word_count,
+        'total_pages': req.body.total_pages,
+        'content': req.body.content,
+        'date_published': req.body.date_published,
+        'dek': req.body.dek,
+        'lead_image_url': req.body.lead_image_url,
+        'title': req.body.title,
+        'rendered_pages': req.body.rendered_pages,
+        'paragraphs': req.body.paragraphs 
+      });
 
-  //       newDoc.save(function(err,newEntry) {
-  //         if (err) {
-  //           res.send(500, err);
-  //         } else {
-  //           res.send(200,newEntry);
-  //         }
-  //       });
-  //     })
-  //   }
-  // });
+      newDoc.save(function(err,newEntry) {
+        if (err) {
+          res.send(500, err);
+        } else {
+          res.send(200,newEntry);
+        }
+      });
+    }
+  });
 };
 
 exports.loginUser = function(req, res) {

--- a/public/client/views/addDocumentView.js
+++ b/public/client/views/addDocumentView.js
@@ -22,9 +22,11 @@ Marginalio.addDocumentView = Backbone.View.extend({
       type: 'POST',
       data: $form,
       success: function(data, status){
-        console.log(JSON.parse(data), status);
         var doc = new Marginalio.Document(JSON.parse(data));
-        doc.save({});
+        doc.on('request', this.startSpinner, this);
+        doc.on('sync', this.success, this);
+        doc.on('error', this.failure, this);
+        doc.save();
       },
       error: function(err){
         console.error('Incomplete POST request',err);

--- a/public/client/views/documentsView.js
+++ b/public/client/views/documentsView.js
@@ -2,8 +2,8 @@ Marginalio.DocumentsView = Backbone.View.extend({
   className: 'documents',
 
   initialize: function(){
-    this.addAll();
-    // this.collection.on('sync', this.addAll, this);
+    // this.addAll();
+    this.collection.on('sync', this.addAll, this);
     this.collection.fetch();
   },
 


### PR DESCRIPTION
Fills out database logic in request-handler:
- makes server-config '/documents endpoint functional
  - Therefore documents properly render on click
- Saves documents added through addDocumentView to database

(Does not save annotations)
